### PR TITLE
Fix typo in fa_IR translations

### DIFF
--- a/rest_framework/locale/fa_IR/LC_MESSAGES/django.po
+++ b/rest_framework/locale/fa_IR/LC_MESSAGES/django.po
@@ -161,7 +161,7 @@ msgstr "این مقدار لازم است."
 
 #: fields.py:317
 msgid "This field may not be null."
-msgstr "این مقدار نباید توهی باشد."
+msgstr "این مقدار نباید تهی باشد."
 
 #: fields.py:701
 msgid "Must be a valid boolean."


### PR DESCRIPTION
Hello and thank you for the developing and maintaining this project.
this PR is nothing important and just fixes a typo in the translations which I encountered today.

below is the entry for the changed word in a widely used Persian online dictionary as proof of validity:
https://www.vajehyab.com/?q=%D8%AA%D9%87%DB%8C
